### PR TITLE
Bump Python to 3.9 in CI

### DIFF
--- a/.ci-build.sh
+++ b/.ci-build.sh
@@ -46,7 +46,7 @@ if [[ "${GROUP}" == downstream* && "${SLUGOWNER}" == "opprop" ]]; then
     clone_downstream () {
         DOWNSTREAM_PROJ="$(pwd -P)/../$1"
         echo "clone downstream to: ${DOWNSTREAM_PROJ}"
-        COMMAND="/tmp/git-scripts/git-clone-related opprop $1 ${DOWNSTREAM_PROJ}"
+        COMMAND="git clone --depth 1 -q -b $2 https://github.com/opprop/$1.git ${DOWNSTREAM_PROJ}"
         echo "Running: ($COMMAND)"
         (eval $COMMAND)
         echo "... done: ($COMMAND)"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Python 3
         uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.9'
       - name: Set up Java
         uses: actions/setup-java@v3
         with:


### PR DESCRIPTION
Python version update to avoid failure in #454.

Recreates opprop/checker-framework-inference#455 from this fork.